### PR TITLE
feat: 가입, 로그인 기능 구현

### DIFF
--- a/sql/trigger.sql
+++ b/sql/trigger.sql
@@ -1,0 +1,23 @@
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+DROP FUNCTION IF EXISTS handle_new_insane_recut_user;
+
+-- 유저 생성후 TB_USER에 유저 추가 함수
+CREATE OR REPLACE FUNCTION public.handle_new_insane_recut_user()
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public."TB_USER" (user_id, nickname, email, created_at)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    split_part(NEW.email, '@', 1),
+    timezone('utc', now())
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 유저 생성후 TB_USER에 유저 추가 함수 트리거
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE PROCEDURE public.handle_new_insane_recut_user();

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,19 @@
+import LoginForm from "../../components/LoginForm";
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h1 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            로그인
+          </h1>
+          <p className="mt-2 text-center text-base text-gray-700">
+            계정에 로그인하여 인생리컷에 참여하세요
+          </p>
+        </div>
+        <LoginForm />
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,19 @@
+import SignUpForm from "../../components/SignupForm";
+
+export default function SignupPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h1 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            인생리컷 가입
+          </h1>
+          <p className="mt-2 text-center text-base text-gray-700">
+            새로운 계정을 만들어 인생리컷에 참여하세요
+          </p>
+        </div>
+        <SignUpForm />
+      </div>
+    </div>
+  );
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "../lib/supabase";
+import { useUserData } from "../lib/useUserData";
+
+export default function LoginForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const router = useRouter();
+  const { getUserData } = useUserData();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (error) {
+        setError(error.message);
+      } else {
+        setSuccess(true);
+        setEmail("");
+        setPassword("");
+
+        // Zustand에 사용자 저장
+        await getUserData();
+
+        // 메인 페이지로 이동
+        router.push("/");
+      }
+    } catch (error) {
+      setError("로그인 중 오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="bg-white p-8 rounded-lg shadow-md">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-green-700 mb-4">
+            로그인 성공!
+          </h2>
+          <p className="text-gray-800 text-base mb-4">
+            성공적으로 로그인되었습니다.
+          </p>
+          <button
+            onClick={() => setSuccess(false)}
+            className="text-blue-700 hover:text-blue-900 font-semibold"
+          >
+            다시 로그인하기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white p-8 rounded-lg shadow-md">
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label
+            htmlFor="email"
+            className="block text-base font-semibold text-gray-900 mb-2"
+          >
+            이메일
+          </label>
+          <input
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600 text-gray-900"
+            placeholder="example@email.com"
+            required
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="password"
+            className="block text-base font-semibold text-gray-900 mb-2"
+          >
+            비밀번호
+          </label>
+          <input
+            type="password"
+            id="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600 text-gray-900"
+            placeholder="비밀번호를 입력하세요"
+            required
+          />
+        </div>
+
+        {error && (
+          <div className="text-red-800 text-base font-medium bg-red-50 p-3 rounded-md border border-red-200">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors font-semibold text-base"
+        >
+          {loading ? "로그인 중..." : "로그인"}
+        </button>
+      </form>
+
+      <div className="mt-6 text-center">
+        <p className="text-base text-gray-800">
+          계정이 없으신가요?{" "}
+          <a
+            href="/signup"
+            className="text-blue-700 hover:text-blue-900 font-semibold"
+          >
+            회원가입
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { supabase } from "../lib/supabase";
+
+export default function SignUpForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+
+    // 비밀번호 확인
+    if (password !== confirmPassword) {
+      setError("비밀번호가 일치하지 않습니다.");
+      setLoading(false);
+      return;
+    }
+
+    // 비밀번호 길이 검증
+    if (password.length < 6) {
+      setError("비밀번호는 6자리 이상이어야 합니다.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+      });
+
+      if (error) {
+        console.log(error);
+        setError(error.message);
+      } else {
+        setSuccess(true);
+        setEmail("");
+        setPassword("");
+        setConfirmPassword("");
+      }
+    } catch (error) {
+      setError("회원가입 중 오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="bg-white p-8 rounded-lg shadow-md">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-green-700 mb-4">
+            회원가입 완료!
+          </h2>
+          <p className="text-gray-800 text-base mb-4">
+            이메일 주소로 확인 링크를 보내드렸습니다.
+          </p>
+          <p className="text-gray-800 text-base mb-4">
+            이메일을 확인하고 계정을 활성화해주세요.
+          </p>
+          <button
+            onClick={() => setSuccess(false)}
+            className="text-blue-700 hover:text-blue-900 font-semibold"
+          >
+            다시 가입하기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white p-8 rounded-lg shadow-md">
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label
+            htmlFor="email"
+            className="block text-base font-semibold text-gray-900 mb-2"
+          >
+            이메일
+          </label>
+          <input
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600 text-gray-900"
+            placeholder="example@email.com"
+            required
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="password"
+            className="block text-base font-semibold text-gray-900 mb-2"
+          >
+            비밀번호
+          </label>
+          <input
+            type="password"
+            id="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600 text-gray-900"
+            placeholder="6자리 이상 입력하세요"
+            required
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="confirmPassword"
+            className="block text-base font-semibold text-gray-900 mb-2"
+          >
+            비밀번호 확인
+          </label>
+          <input
+            type="password"
+            id="confirmPassword"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 placeholder-gray-600 text-gray-900"
+            placeholder="위와 동일한 비밀번호"
+            required
+          />
+        </div>
+
+        {error && (
+          <div className="text-red-800 text-base font-medium bg-red-50 p-3 rounded-md border border-red-200">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 text-white py-3 px-4 rounded-md hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors font-semibold text-base"
+        >
+          {loading ? "가입 중..." : "회원가입"}
+        </button>
+      </form>
+
+      <div className="mt-6 text-center">
+        <p className="text-base text-gray-800">
+          이미 계정이 있으신가요?{" "}
+          <a
+            href="/login"
+            className="text-blue-700 hover:text-blue-900 font-semibold"
+          >
+            로그인
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from "@supabase/supabase-js";
 
-const SUPABASE_URL = "https://jpdvffedhgppdtxkskel.supabase.co"
-const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpwZHZmZmVkaGdwcGR0eGtza2VsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTE0Mzg5ODYsImV4cCI6MjA2NzAxNDk4Nn0.3E2cz9QkxkZnd6OwGVDWKM5fXSwCyQq9pbRjMg65vkw"
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY) 
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/src/lib/useUserData.ts
+++ b/src/lib/useUserData.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { supabase } from "./supabase";
+import { useUserStore } from "../stores/userStore";
+
+export function useUserData() {
+  const { setLoading, setUser, clearUser } = useUserStore();
+
+  const getUserData = async () => {
+    setLoading(true);
+
+    const { data } = await supabase.auth.getUser();
+
+    if (data.user) {
+      setUser({
+        user_id: data.user.id,
+        nickname: data.user.email ? data.user.email.split("@")[0] : "undefined",
+        email: data.user.email ? data.user.email : "undefined",
+        created_at: data.user.created_at,
+      });
+      setLoading(false);
+      return { success: true, user: data.user };
+    } else {
+      clearUser();
+      setLoading(false);
+      return { success: false, error: "사용자 없음" };
+    }
+  };
+
+  return { getUserData };
+}

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -1,17 +1,19 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
-import { User, UserState } from '@/types/user'
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { User, UserState } from "@/types/user";
 
 export const useUserStore = create<UserState>()(
   persist(
     (set) => ({
       user: null,
+      isLoading: false,
       setUser: (user: User | null) => set({ user }),
+      setLoading: (isLoading) => set({ isLoading }),
       clearUser: () => set({ user: null }),
     }),
     {
-      name: 'insane-recut-user', // localStorage key
+      name: "insane-recut-user", // localStorage key
       partialize: (state) => ({ user: state.user }),
     }
   )
-) 
+);

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,12 +1,14 @@
 export interface User {
-  user_id: string
-  email: string
-  nickname: string
-  created_at: string
+  user_id: string;
+  email: string;
+  nickname: string;
+  created_at: string;
 }
 
 export interface UserState {
-  user: User | null
-  setUser: (user: User | null) => void
-  clearUser: () => void
-} 
+  user: User | null;
+  isLoading: boolean;
+  setUser: (user: User | null) => void;
+  setLoading: (loading: boolean) => void;
+  clearUser: () => void;
+}


### PR DESCRIPTION
### 어떤 내용인가요?

- 회원가입 (singup) 및 로그인 (login) 구현
- **회원가입**
  - ```/signup``` 페이지에서 이메일, 비밀번호를 통해 회원가입 수행
  - ```auth.users```에 신규 유저가 삽입될 때, trigger 실행 (```TB_USER```에 삽입)
  - ```nickname```은 ```email```을 ```@```로 잘라서 0번째 나오는 값으로 기입
- **로그인**
  - ```/login``` 페이지에서 이메일, 비밀번호를 통해 로그인
  - 로그인 완료시 로컬스토리지 ```insane-recut-user``` 키에 유저 정보 저장


### 어떤 유형인가요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 빌드 관련 수정
- [ ] 테스트 추가, 테스트 리팩토링
